### PR TITLE
More complete ACL permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 .*.swo
 hamper.conf
 hamper.db
-bin/
-include/
-lib/
+/bin/
+/include/
+/lib/
 dropin.cache
 build/
-_trial_temp/
+/_trial_temp*/
 hamper.acl
+/man/

--- a/hamper/acl.py
+++ b/hamper/acl.py
@@ -1,23 +1,35 @@
 import json
+import re
 
 
 class AllowAllACL(object):
-    def hasPermission(self, comm, thing):
+    def has_permission(self, comm, thing):
         return True
 
 
 class ACL(object):
+
+    ALLOW = 1
+    DENY = 2
+
     def __init__(self, acl):
         self.acls = json.loads(acl)
         self.permissions = self.acls['permissions']
 
-    def hasPermission(self, comm, thing):
-        channel = comm['channel']
+    def has_permission(self, comm, thing):
+        allow, deny = False, False
+        self.add_groups(comm)
 
-        # First, is this command allowed in this channel?
-        if self.commandChannelPermission(channel, thing):
-            return True
-        return False
+        for selector, permissions in self.acls['permissions'].items():
+            if self.match_selector(selector, comm):
+                for p in permissions:
+                    policy = self.glob_permission_match(thing, p)
+                    if policy == self.ALLOW:
+                        allow = True
+                    elif policy == self.DENY:
+                        deny = True
+
+        return allow and not deny
 
     def commandChannelPermission(self, channel, thing):
         channel_perms = self.permissions.get(channel, None)
@@ -29,3 +41,60 @@ class ACL(object):
             if thing in channel_perms:
                 return True
         return False
+
+    def match_selector(self, selector, comm):
+        parsed = self.parse_selector(selector)
+        for key, val in parsed.items():
+            if key == 'group':
+                if val not in comm['groups']:
+                    return False
+            else:
+                if comm[key] != val:
+                    return False
+
+        return True
+
+    def parse_selector(self, selector):
+        if selector == '*':
+            return {}
+
+        user = re.search(r'^([^@#]+)', selector)
+        group = re.search(r'(@[^@#]+)', selector)
+        channel = re.search(r'(#[^@#]+)', selector)
+
+        parsed = {}
+        if user:
+            parsed['user'] = user.groups()[0]
+        if group:
+            parsed['group'] = group.groups()[0]
+        if channel:
+            parsed['channel'] = channel.groups()[0]
+
+        return parsed
+
+    def glob_permission_match(self, permission, pattern):
+        if pattern[0] == '-':
+            ret = self.DENY
+            pattern = pattern[1:]
+        else:
+            ret = self.ALLOW
+
+        permissions = permission.split('.')
+        patterns = pattern.split('.')
+
+        if len(permissions) != len(patterns) and patterns[-1] != '*':
+            return False
+
+        for perm, pat in zip(permissions, patterns):
+            if perm != pat and pat != '*':
+                return None
+        return ret
+
+    def add_groups(self, comm):
+        user = comm['user']
+        comm['groups'] = []
+        for name, members in self.acls['groups'].items():
+            if user in members:
+                comm['groups'].append(name)
+        # Yes it is modified, but returning it is nice too.
+        return comm

--- a/hamper/plugins/factoid.py
+++ b/hamper/plugins/factoid.py
@@ -46,7 +46,7 @@ class Factoids(ChatPlugin):
         if not match:
             return
 
-        if not bot.acl.hasPermission(comm, 'factoid'):
+        if not bot.acl.has_permission(comm, 'factoid'):
             bot.reply(comm, "I cannot learn new things")
             return
 
@@ -79,7 +79,7 @@ class Factoids(ChatPlugin):
         if not match:
             return
 
-        if not bot.acl.hasPermission(comm, 'factoid'):
+        if not bot.acl.has_permission(comm, 'factoid'):
             bot.reply(comm, "Never Forget!")
             return
 
@@ -107,7 +107,7 @@ class Factoids(ChatPlugin):
         if not match:
             return
 
-        if not bot.acl.hasPermission(comm, 'factoid'):
+        if not bot.acl.has_permission(comm, 'factoid'):
             bot.reply(comm, "Never Forget!")
             return
 

--- a/hamper/tests/test_permissions.py
+++ b/hamper/tests/test_permissions.py
@@ -1,58 +1,187 @@
-try:
-    import StringIO
-except ImportError:
-    from io import StringIO  # Python 3
-
+import json
 from unittest import TestCase
 
 from hamper.acl import ACL
 
-TEST_ACL = """
-{
-    "permissions": {
-        "#channel": [
-            "*"
-        ],
-        "#channel1": [
-            "figlet",
-            "quote",
-            "-quote.add"
-        ],
-        "#channel2": [
-            "*",
-            "-figlet"
-        ]
+TEST_ACL = json.dumps({
+    'groups': {
+        '@ops': ['uberj', 'mythmon'],
+        '@spammers': ['spambot'],
+        '@7letters': ['mythmon', 'spambot'],
+    },
+    'permissions': {
+        '#channel1': ['figlet', 'quote', '-quote.add'],
+        '#channel2': ['*', '-figlet'],
+        '@ops': ['*'],
+        'mythmon': ['quote.*'],
     }
-}
-"""
+})
 
 
 class TestACL(TestCase):
+    def setUp(self):
+        self.acl = ACL(TEST_ACL)
+
     def test_channel_star_perms(self):
-        acl = ACL(StringIO.StringIO(TEST_ACL.strip('\n')).read())
         comm = {
             'user': 'uberj',
-            'channel': '#channel',
-        }
-        self.assertTrue(acl.hasPermission(comm, 'foo'))
-
-    def test_channel_perms(self):
-        acl = ACL(StringIO.StringIO(TEST_ACL).read())
-        comm = {
-            'user': 'foobar',  # not in any groups
-            'channel': '#channel1',
-        }
-        self.assertTrue(acl.hasPermission(comm, 'figlet'))
-        self.assertTrue(acl.hasPermission(comm, 'quote'))
-        self.assertFalse(acl.hasPermission(comm, 'quote.add'))
-        self.assertFalse(acl.hasPermission(comm, 'channel.leave'))
-
-    def test_channel_everything_but_figlet(self):
-        acl = ACL(StringIO.StringIO(TEST_ACL).read())
-        comm = {
-            'user': 'foobar',  # not in any groups
             'channel': '#channel2',
         }
-        self.assertTrue(acl.hasPermission(comm, 'cmd'))
-        self.assertTrue(acl.hasPermission(comm, 'anothercmd'))
-        self.assertFalse(acl.hasPermission(comm, 'figlet'))
+        self.assertTrue(self.acl.has_permission(comm, 'foo'))
+
+    def test_channel_perms(self):
+        comm = {
+            'user': 'foobar',
+            'channel': '#channel1',
+        }
+        self.assertTrue(self.acl.has_permission(comm, 'figlet'))
+        self.assertTrue(self.acl.has_permission(comm, 'quote'))
+        self.assertFalse(self.acl.has_permission(comm, 'quote.add'))
+        self.assertFalse(self.acl.has_permission(comm, 'channel.leave'))
+
+    def test_channel_everything_but_figlet(self):
+        comm = {
+            'user': 'foobar',
+            'channel': '#channel2',
+        }
+        self.assertTrue(self.acl.has_permission(comm, 'cmd'))
+        self.assertTrue(self.acl.has_permission(comm, 'anothercmd'))
+        self.assertFalse(self.acl.has_permission(comm, 'figlet'))
+
+    def test_group_permissions(self):
+        comm = {
+            'user': 'uberj',
+            'channel': '#channel3',
+            # group will be filled in as '@op'
+        }
+        self.assertTrue(self.acl.has_permission(comm, 'cmd'))
+
+        comm['channel'] = '#channel2'
+        # Not even ops can use figlet here.
+        self.assertFalse(self.acl.has_permission(comm, 'figlet'))
+
+    def test_user_permission(self):
+        comm = {
+            'user': 'mythmon',
+            'channel': '#channel3',
+        }
+        self.assertTrue(self.acl.has_permission(comm, 'quote'))
+        self.assertTrue(self.acl.has_permission(comm, 'quote.add'))
+        self.assertTrue(self.acl.has_permission(comm, 'quote.delete'))
+
+
+class TestACLParser(TestCase):
+    def setUp(self):
+        self.acl = ACL(TEST_ACL)
+
+    def _check(self, selector, expected):
+        acl = ACL(TEST_ACL)
+        self.assertEqual(acl.parse_selector(selector), expected)
+
+    # 0 items
+
+    def test_star(self):
+        self._check('*', {})
+
+    # 1 items
+
+    def test_user(self):
+        self._check('foo', {'user': 'foo'})
+        self._check('bar', {'user': 'bar'})
+
+    def test_group(self):
+        self._check('@foo', {'group': '@foo'})
+        self._check('@bar', {'group': '@bar'})
+
+    def test_channel(self):
+        self._check('#foo', {'channel': '#foo'})
+        self._check('#bar', {'channel': '#bar'})
+
+    # 2 items
+
+    def test_user_group(self):
+        self._check('foo@bar', {'user': 'foo', 'group': '@bar'})
+        self._check('baz@qux', {'user': 'baz', 'group': '@qux'})
+
+    def test_user_channel(self):
+        self._check('foo#bar', {'user': 'foo', 'channel': '#bar'})
+        self._check('baz#qux', {'user': 'baz', 'channel': '#qux'})
+
+    def test_group_channel(self):
+        self._check('@foo#bar', {'group': '@foo', 'channel': '#bar'})
+        self._check('#baz@qux', {'channel': '#baz', 'group': '@qux'})
+
+    # 3 items
+
+    def test_user_channel_group(self):
+        self._check('foo@bar#baz', {
+            'user': 'foo',
+            'group': '@bar',
+            'channel': '#baz',
+        })
+        self._check('foo#baz@bar', {
+            'user': 'foo',
+            'group': '@bar',
+            'channel': '#baz',
+        })
+
+
+class TestPermissionGlobbing(TestCase):
+
+    def setUp(self):
+        self.acl = ACL(TEST_ACL)
+
+    def _check(self, perm, pattern, match=ACL.ALLOW):
+        if match:
+            self.assertTrue(self.acl.glob_permission_match(perm, pattern))
+        else:
+            self.assertFalse(self.acl.glob_permission_match(perm, pattern))
+
+    def test_single(self):
+        self._check('foo', 'foo')
+        self._check('foo', 'bar', None)
+
+    def test_dotted(self):
+        self._check('foo.bar', 'foo.bar')
+        self._check('foo.bar', 'foo.baz', None)
+
+    def test_partial(self):
+        self._check('foo', 'foo.bar', None)
+        self._check('foo.bar', 'foo', None)
+
+    def test_end_star(self):
+        self._check('foo.bar', 'foo.*')
+        self._check('foo.bar', 'bar.*', None)
+
+    def test_middle_star(self):
+        self._check('foo.bar.baz', 'foo.*.baz')
+        self._check('foo.bar.baz', 'foo.*.qux', None)
+
+    def test_partial_star(self):
+        self._check('foo.bar.baz', 'foo.*')
+        self._check('foo.bar.baz', 'bar.*', None)
+
+    def test_negation(self):
+        self._check('foo', '-foo', ACL.DENY)
+        self._check('foo.bar', '-foo.bar', ACL.DENY)
+        self._check('foo', '-foo.bar', None)
+
+
+class TestAddGroups(TestCase):
+
+    def setUp(self):
+        self.acl = ACL(TEST_ACL)
+
+    def test_single(self):
+        comm = {'user': 'uberj'}
+        self.assertEqual(self.acl.add_groups(comm)['groups'], ['@ops'])
+
+    def test_double(self):
+        comm = {'user': 'mythmon'}
+        groups = set(self.acl.add_groups(comm)['groups'])
+        expected = set(['@ops', '@7letters'])
+        self.assertEqual(groups, expected)
+
+    def test_none(self):
+        comm = {'user': 'edunham'}
+        self.assertEqual(self.acl.add_groups(comm)['groups'], [])


### PR DESCRIPTION
I finished the selector engine for ACLs. Now there are group, channel, and user based ACLs, and they can be mixed.

The ACLs work in a deny/allow fashion. If any rule denies the request, it is denied, no matter how many rules allow the request. This might make things tricky, but I don't think it will be a huge problem, because ACLs are _deny by default_. I want to see how people (want to) actually use this and then iterate.

r?
