### PR TITLE
Fix acl dist

### DIFF
--- a/hamper.conf.dist
+++ b/hamper.conf.dist
@@ -8,10 +8,7 @@ port: 6667
 db: "sqlite:///hamper.db"
 
 # Uncomment and setup .acl file if you need it
-# Patches welcome!
 # acl: hamper.acl
-
-acl: hamper.acl
 
 channels: ["#awesome-channel", "#cool-channel"]
 plugins:


### PR DESCRIPTION
`hamper.conf.dist` is a bad example, because it links to a non-existant acls file. This fixes that, hopefully in a better way that pull #40.

@chance, r?
