### PR TITLE
Fix README.md to point to correct clone location

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Quick Start
 -----------
 
 ```shell
-$ git clone https://github.com/mythmon/hamper
+$ git clone https://github.com/hamperbot/hamper
 $ cd hamper
 $ virtualenv venv
 $ source venv/bin/activate


### PR DESCRIPTION
README.md was still pointing to mythmon/hamper, but the hamperbot organization is now the owner.
