### PR TITLE
add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 /_trial_temp*/
 hamper.acl
 /man/
+/venv/
 
 dist/
 hamper.egg-info/


### PR DESCRIPTION
add venv to gitignore, since it's in the quickstart, and it doesn't belong in git.
