### PR TITLE
Plugins: Stop instantiating plugins at the bottom of the file.

### DIFF
--- a/hamper/plugins/bitly.py
+++ b/hamper/plugins/bitly.py
@@ -92,6 +92,3 @@ class Bitly(ChatPlugin):
 
         # Always let the other plugins run
         return False
-
-
-bitly = Bitly()

--- a/hamper/plugins/channel_utils.py
+++ b/hamper/plugins/channel_utils.py
@@ -45,6 +45,3 @@ class ChannelUtils(ChatCommandPlugin):
                 chan = '#' + chan
             bot.reply(comm, 'Bye!')
             bot.leave(chan)
-
-
-channel_utils = ChannelUtils()

--- a/hamper/plugins/commands.py
+++ b/hamper/plugins/commands.py
@@ -205,10 +205,3 @@ class Dice(ChatCommandPlugin):
             output += "for a total of %s" % sum(result)
 
             bot.say(com['channel'], output)
-
-
-lmgtfy = LetMeGoogleThatForYou()
-rot13 = Rot13()
-sed = Sed()
-quit = Quit()
-dice = Dice()

--- a/hamper/plugins/dictionary.py
+++ b/hamper/plugins/dictionary.py
@@ -96,6 +96,3 @@ class Lookup(ChatCommandPlugin):
 
             # Always let the other plugins run
             return False
-
-
-lookup = Lookup()

--- a/hamper/plugins/factoids.py
+++ b/hamper/plugins/factoids.py
@@ -178,6 +178,3 @@ class Factoid(SQLAlchemyBase):
         self.trigger = trigger
         self.action = action
         self.response = response
-
-
-factoids = Factoids()

--- a/hamper/plugins/flip.py
+++ b/hamper/plugins/flip.py
@@ -31,6 +31,3 @@ class Flip(ChatCommandPlugin):
                 ret = u'ಠ_ಠ'.encode('utf-8')
             bot.reply(comm, ret, encode=False)
             return True
-
-
-quotes = Flip()

--- a/hamper/plugins/friendly.py
+++ b/hamper/plugins/friendly.py
@@ -74,8 +74,3 @@ class BotSnack(ChatPlugin):
                 return True
 
         return False
-
-
-friendly = Friendly()
-omgponies = OmgPonies()
-botsnack = BotSnack()

--- a/hamper/plugins/goodbye.py
+++ b/hamper/plugins/goodbye.py
@@ -27,6 +27,3 @@ class GoodBye(ChatPlugin):
                 return True
 
         return False
-
-
-goodbye = GoodBye()

--- a/hamper/plugins/help.py
+++ b/hamper/plugins/help.py
@@ -68,5 +68,3 @@ class Help(ChatCommandPlugin):
                 bot.reply(comm, '{0.short_desc}'.format(command))
                 if command.long_desc:
                     bot.reply(comm, '{0.long_desc}'.format(command))
-
-help = Help()

--- a/hamper/plugins/karma.py
+++ b/hamper/plugins/karma.py
@@ -379,6 +379,3 @@ class KarmaStatsTable(SQLAlchemyBase):
         self.giver = giver
         self.receiver = receiver
         self.kcount = kcount
-
-
-karma = Karma()

--- a/hamper/plugins/plugin_utils.py
+++ b/hamper/plugins/plugin_utils.py
@@ -76,6 +76,3 @@ class PluginUtils(ChatCommandPlugin):
             bot.factory.loader.removePlugin(target_plugin)
             bot.reply(comm, 'Unloading {0}.'.format(target_plugin))
             return True
-
-
-plugin_utils = PluginUtils()

--- a/hamper/plugins/questions.py
+++ b/hamper/plugins/questions.py
@@ -146,10 +146,6 @@ class ChoicesPlugin(ChatCommandPlugin):
             return choices
 
 
-yesno = YesNoPlugin()
-choices = ChoicesPlugin()
-
-
 if __name__ == '__main__':
     import doctest
     doctest.testmod()

--- a/hamper/plugins/quotes.py
+++ b/hamper/plugins/quotes.py
@@ -73,6 +73,3 @@ class Quote(SQLAlchemyBase):
         self.text = text
         self.adder = adder
         self.added = added
-
-
-quotes = Quotes()

--- a/hamper/plugins/roulette.py
+++ b/hamper/plugins/roulette.py
@@ -29,5 +29,3 @@ class Roulette(ChatCommandPlugin):
                 bot.reply(comm, "*click*")
 
             return True
-
-roulette = Roulette()

--- a/hamper/plugins/seen.py
+++ b/hamper/plugins/seen.py
@@ -116,5 +116,3 @@ class SeenTable(SQLAlchemyBase):
 
     def __repr__(self):
         return "<Seen %s>" % self
-
-seen = Seen()

--- a/hamper/plugins/suggest.py
+++ b/hamper/plugins/suggest.py
@@ -54,6 +54,3 @@ class Suggest(ChatCommandPlugin):
 
             # Always let the other plugins run
             return False
-
-
-suggest = Suggest()

--- a/hamper/plugins/timez.py
+++ b/hamper/plugins/timez.py
@@ -60,6 +60,3 @@ class Timez(ChatCommandPlugin):
 
             # Always let the other plugins run
             return False
-
-
-timez = Timez()

--- a/hamper/plugins/tinyurl.py
+++ b/hamper/plugins/tinyurl.py
@@ -81,6 +81,3 @@ class Tinyurl(ChatPlugin):
 
         # Always let the other plugins run
         return False
-
-
-tinyurl = Tinyurl()


### PR DESCRIPTION
As noted in the README, this practice is no longer necessary.
The plugin loader will instantiate each plugin.