### PR TITLE
Plugins: Fix help plugin.

### DIFF
--- a/hamper/plugins/help.py
+++ b/hamper/plugins/help.py
@@ -20,13 +20,12 @@ class Help(ChatCommandPlugin):
     @classmethod
     def helpful_commands(cls, bot):
         commands = set()
-        for kind, plugins in bot.factory.loader.plugins.items():
-            for plugin in plugins:
-                if (hasattr(plugin, 'name') and hasattr(plugin, 'short_desc')
-                        and hasattr(plugin, 'long_desc')):
-                    commands.add(plugin)
+        for plugin in bot.factory.loader.plugins:
+            if (hasattr(plugin, 'name') and hasattr(plugin, 'short_desc')
+                    and hasattr(plugin, 'long_desc')):
+                commands.add(plugin)
 
-                commands.update(plugin.commands)
+            commands.update(plugin.commands)
 
         for cmd in commands:
             if getattr(cmd, 'short_desc', None) is not None:


### PR DESCRIPTION
This is the minimum necessary change to get help working again with the new
plugin system.

Of course, it also needs to be rewritten to be less verbose so that it doesn't
trigger flooding countermeasures, but that's a change for another time.