### PR TITLE
need absolute path for COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ VOLUME $HAMPER_DB_DIR
 ENV DATABASE_URL sqlite:///$HAMPER_DB_DIR/hamper.db
 
 # helps with caching
-COPY requirements.txt requirements.txt
+COPY requirements.txt /usr/src/hamper/requirements.txt
 RUN pip install -r requirements.txt
 
 COPY . /usr/src/hamper


### PR DESCRIPTION
The COPY directive for the Dockerfile needs an absolute path to get the requirements.txt file to copy correctly.

This was for Docker version 1.3.3, build d344625 on Debian Jessie.
