### PR TITLE
Use Travis CI's container based infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: '2.7'
+sudo: false
 
 before_script:
     - pyflakes hamper


### PR DESCRIPTION
It is significantly faster than the VM based infrastructure on a good day.
Hamper currently defaults to the old VM based infrastructure.
http://docs.travis-ci.com/user/workers/container-based-infrastructure/