### PR TITLE
Don't shorten URLs shorter than Bitly URLs

### DIFF
--- a/hamper/plugins/bitly.py
+++ b/hamper/plugins/bitly.py
@@ -67,7 +67,7 @@ class Bitly(ChatPlugin):
             long_url = match.group(0)
 
             # Only shorten urls which are longer than a bitly url (12 chars)
-            if len(long_url) <= 12:
+            if len(long_url) <= 21:
                 return False
 
             # Don't shorten url's which are in the exclude list

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requires = open('requirements.txt').read().split('\n')
 
 setup(
     name='hamper',
-    version='1.11.0',
+    version='1.11.1',
     description='Yet another IRC bot',
     install_requires=requires,
     author='Mike Cooper',


### PR DESCRIPTION
Whoever calculated the old hardcoded length forgot to include the protocol.

Thank you for improving Hamper!

Check one:

- [x] I remembered to bump the version
- [ ] This is a typo fix and no version bump is necessary

Does this fix an issue?

- [x] Fixes #129 

Do you want this change to show up in the LUG hamper?

- [x] I PR'd a version bump to [LUG hamper](https://github.com/hamperbot/hamper-lug/blob/master/requirements.txt)
