### PR TITLE
If someone PMs the bot, they likely want a reply.

### DIFF
--- a/hamper/commander.py
+++ b/hamper/commander.py
@@ -103,6 +103,8 @@ class CommanderProtocol(irc.IRCClient):
             raw_message, re.I).groups()
 
         pm = channel == self.nickname
+        if pm:
+            directed = True
         if target:
             if target.lower() == self.nickname.lower():
                 directed = True


### PR DESCRIPTION
"Directed" appears to be an umbrella encompassing all messages which a user
sends with the explicit intent of getting the bot to reply.

The other way to fix the "questions in PM without the bot's nick don't get
replies" bug would be to check for PM in every plugin alongside checking
directed, but that seems silly.

Thank you for improving Hamper!

Check one:

- [ ] I remembered to bump the version
- [ ] This is a typo fix and no version bump is necessary
- [x] the version was very pretty so i didn't want to change it

Does this fix an issue?

- [ ] Fixes #____

Do you want this change to show up in the LUG hamper?

- [ ] I PR'd a version bump to [LUG hamper](https://github.com/hamperbot/hamper-lug/blob/master/requirements.txt)
